### PR TITLE
Cleaned up a little and fixed bug re: text drawing

### DIFF
--- a/const.h
+++ b/const.h
@@ -17,17 +17,8 @@
 
 #define DISPLAY    ":0.0"
 
-#define CONSOLE_STR     "console"
-#define HALT_STR        "halt"
-#define REBOOT_STR      "reboot"
-#define EXIT_STR        "exit"
-#define SUSPEND_STR     "suspend"
-
 #define HIDE        0
 #define SHOW        1
-
-#define GET_NAME    0
-#define GET_PASSWD  1
 
 #define OK_EXIT     0
 #define ERR_EXIT    1

--- a/panel.cpp
+++ b/panel.cpp
@@ -342,6 +342,7 @@ bool Panel::OnKeyPress(XEvent& event) {
     int yy;
     string text;
     string formerString = "";
+    bool fieldTextChanged = true;
     
     XLookupString(&event.xkey, &ascii, 1, &keysym, &compstatus);
     switch(keysym){
@@ -390,6 +391,8 @@ bool Panel::OnKeyPress(XEvent& event) {
                     PasswdBuffer.append(&ascii,1);
                     HiddenPasswdBuffer.append("*");
                 };
+            } else {
+                fieldTextChanged = false;
             };
             break;
     };
@@ -415,7 +418,7 @@ bool Panel::OnKeyPress(XEvent& event) {
                    maxLength+6, maxHeight+6, false);
     }
 
-    if (!text.empty()) {
+    if (fieldTextChanged) {
         SlimDrawString8 (draw, &inputcolor, font, xx, yy,
                          text,
                          &inputshadowcolor,

--- a/panel.cpp
+++ b/panel.cpp
@@ -361,73 +361,34 @@ bool Panel::OnKeyPress(XEvent& event) {
     switch(keysym){
         case XK_Delete:
         case XK_BackSpace:
-            switch(field) {
-                case GET_NAME:
-                    if (! NameBuffer.empty()){
-                        formerString=NameBuffer;
-                        NameBuffer.erase(--NameBuffer.end());
-                    };
-                    break;
-                case GET_PASSWD:
-                    if (! PasswdBuffer.empty()){
-                        formerString=HiddenPasswdBuffer;
-                        PasswdBuffer.erase(--PasswdBuffer.end());
-                        HiddenPasswdBuffer.erase(--HiddenPasswdBuffer.end());
-                    };
-                    break;
+            if (! PasswdBuffer.empty()){
+                formerString=HiddenPasswdBuffer;
+                PasswdBuffer.erase(--PasswdBuffer.end());
+                HiddenPasswdBuffer.erase(--HiddenPasswdBuffer.end());
             };
             break;
         case XK_Escape:
-            switch(field) {
-                case GET_NAME:
-                    if (! NameBuffer.empty()){
-                        formerString = NameBuffer;
-                        NameBuffer.clear();
-                    };
-                    break;
-                case GET_PASSWD:
-                    if (! PasswdBuffer.empty()){
-                        formerString = HiddenPasswdBuffer;
-                        PasswdBuffer.clear();
-                        HiddenPasswdBuffer.clear();
-                    };
-                    break;
+            if (! PasswdBuffer.empty()){
+                formerString = HiddenPasswdBuffer;
+                PasswdBuffer.clear();
+                HiddenPasswdBuffer.clear();
             };
+            break;
         case XK_w:
         case XK_u:
             if (reinterpret_cast<XKeyEvent&>(event).state & ControlMask) {
-                switch(field) {
-                    case GET_PASSWD:
-                        formerString = HiddenPasswdBuffer;
-                        HiddenPasswdBuffer.clear();
-                        PasswdBuffer.clear();
-                        break;
-
-                    case GET_NAME:
-                        formerString = NameBuffer;
-                        NameBuffer.clear();
-                        break;
-                };
-                break;
-            }
+                formerString = HiddenPasswdBuffer;
+                HiddenPasswdBuffer.clear();
+                PasswdBuffer.clear();
+            };
             // Deliberate fall-through
         
         default:
             if (isprint(ascii) && (keysym < XK_Shift_L || keysym > XK_Hyper_R)){
-                switch(field) {
-                    case GET_NAME:
-                        formerString=NameBuffer;
-                        if (NameBuffer.length() < INPUT_MAXLENGTH_NAME-1){
-                            NameBuffer.append(&ascii,1);
-                        };
-                        break;
-                    case GET_PASSWD:
-                        formerString=HiddenPasswdBuffer;
-                        if (PasswdBuffer.length() < INPUT_MAXLENGTH_PASSWD-1){
-                            PasswdBuffer.append(&ascii,1);
-                            HiddenPasswdBuffer.append("*");
-                        };
-                    break;
+                formerString=HiddenPasswdBuffer;
+                if (PasswdBuffer.length() < INPUT_MAXLENGTH_PASSWD-1){
+                    PasswdBuffer.append(&ascii,1);
+                    HiddenPasswdBuffer.append("*");
                 };
             };
             break;
@@ -437,20 +398,10 @@ bool Panel::OnKeyPress(XEvent& event) {
     XftDraw *draw = XftDrawCreate(Dpy, Win,
                                   DefaultVisual(Dpy, Scr), DefaultColormap(Dpy, Scr));
 
-   switch(field) {
-        case GET_NAME:
-            text = NameBuffer;
-            xx = input_name_x;
-            yy = input_name_y;
-            break;
-
-        case GET_PASSWD:
-            text = HiddenPasswdBuffer;
-            xx = input_pass_x;
-            yy = input_pass_y;
-            break;
-    }
-
+    text = HiddenPasswdBuffer;
+    xx = input_pass_x;
+    yy = input_pass_y;
+    
     if (!formerString.empty()){
         const char* txth = "Wj"; // get proper maximum height ?
         XftTextExtents8(Dpy, font, reinterpret_cast<const XftChar8*>(txth), strlen(txth), &extents);

--- a/panel.cpp
+++ b/panel.cpp
@@ -244,13 +244,13 @@ void Panel::Cursor(int visible) {
     const char* txth = "Wj"; // used to get cursor height
 
     switch(field) {
-        case Get_Passwd:
+        case GET_PASSWD:
             text = HiddenPasswdBuffer.c_str();
             xx = input_pass_x;
             yy = input_pass_y;
             break;
 
-        case Get_Name:
+        case GET_NAME:
             text = NameBuffer.c_str();
             xx = input_name_x;
             yy = input_name_y;
@@ -312,14 +312,14 @@ void Panel::OnExpose(void) {
                          inputShadowXOffset, inputShadowYOffset);
     } else { //single input mode
         switch(field) {
-            case Get_Passwd:
+            case GET_PASSWD:
                 SlimDrawString8 (draw, &inputcolor, font,
                                  input_pass_x, input_pass_y,
                                  HiddenPasswdBuffer,
                                  &inputshadowcolor,
                                  inputShadowXOffset, inputShadowYOffset);
                 break;
-            case Get_Name:
+            case GET_NAME:
                 SlimDrawString8 (draw, &inputcolor, font,
                                  input_name_x, input_name_y,
                                  NameBuffer,
@@ -382,14 +382,14 @@ bool Panel::OnKeyPress(XEvent& event) {
                 case GET_NAME:
                     if (! NameBuffer.empty()){
                         formerString = NameBuffer;
-                        NameBuffer = "";
+                        NameBuffer.clear();
                     };
                     break;
                 case GET_PASSWD:
                     if (! PasswdBuffer.empty()){
                         formerString = HiddenPasswdBuffer;
-                        PasswdBuffer = "";
-                        HiddenPasswdBuffer = "";
+                        PasswdBuffer.clear();
+                        HiddenPasswdBuffer.clear();
                     };
                     break;
             };
@@ -397,13 +397,13 @@ bool Panel::OnKeyPress(XEvent& event) {
         case XK_u:
             if (reinterpret_cast<XKeyEvent&>(event).state & ControlMask) {
                 switch(field) {
-                    case Get_Passwd:
+                    case GET_PASSWD:
                         formerString = HiddenPasswdBuffer;
                         HiddenPasswdBuffer.clear();
                         PasswdBuffer.clear();
                         break;
 
-                    case Get_Name:
+                    case GET_NAME:
                         formerString = NameBuffer;
                         NameBuffer.clear();
                         break;
@@ -438,13 +438,13 @@ bool Panel::OnKeyPress(XEvent& event) {
                                   DefaultVisual(Dpy, Scr), DefaultColormap(Dpy, Scr));
 
    switch(field) {
-        case Get_Name:
+        case GET_NAME:
             text = NameBuffer;
             xx = input_name_x;
             yy = input_name_y;
             break;
 
-        case Get_Passwd:
+        case GET_PASSWD:
             text = HiddenPasswdBuffer;
             xx = input_pass_x;
             yy = input_pass_y;
@@ -507,7 +507,7 @@ void Panel::ShowText(){
 
     /* Enter username-password message */
     string msg;
-    if (!singleInputMode|| field == Get_Passwd ) {
+    if (!singleInputMode|| field == GET_PASSWD ) {
         msg = cfg->getOption("password_msg");
         XftTextExtents8(Dpy, enterfont, (XftChar8*)msg.c_str(),
                         strlen(msg.c_str()), &extents);
@@ -524,7 +524,7 @@ void Panel::ShowText(){
                              msg, &entershadowcolor, shadowXOffset, shadowYOffset);
         }
     }
-    if (!singleInputMode|| field == Get_Name ) {
+    if (!singleInputMode|| field == GET_NAME ) {
         msg = cfg->getOption("username_msg");
         XftTextExtents8(Dpy, enterfont, (XftChar8*)msg.c_str(),
                         strlen(msg.c_str()), &extents);

--- a/panel.h
+++ b/panel.h
@@ -38,8 +38,8 @@
 class Panel {
 public:
     enum FieldType {
-        Get_Name,
-        Get_Passwd
+        GET_NAME,
+        GET_PASSWD
     };
 
 

--- a/slimlock.cpp
+++ b/slimlock.cpp
@@ -228,7 +228,7 @@ void HideCursor()
 
 bool AuthenticateUser()
 {
-    loginPanel->EventHandler(Panel::Get_Passwd);
+    loginPanel->EventHandler(Panel::GET_PASSWD);
     
     char *encrypted, *correct;
     struct passwd *pw;


### PR DESCRIPTION
As stated in the commit message, I fixed a bug in panel.cpp that would cause the text to be drawn repeatedly without being cleared when function keys or other non-input keys were pressed. Note that this bug is from slim itself and did not come from your work.

Tossing in a boolean to check if anything's changed doesn't seem like the best solution, but it's the simplest I could come up with.
