### PR TITLE
Option to enable/disable tty locking

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -31,6 +31,7 @@ Cfg::Cfg()
     options.insert(option("welcome_msg", "Welcome to %host"));
     options.insert(option("current_theme", "default"));
     options.insert(option("hidecursor", "false"));
+    options.insert(option("tty_lock", "true"));
 
     // Theme stuff
     options.insert(option("input_panel_x", "50%"));

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -31,7 +31,6 @@ Cfg::Cfg()
     options.insert(option("welcome_msg", "Welcome to %host"));
     options.insert(option("current_theme", "default"));
     options.insert(option("hidecursor", "false"));
-    options.insert(option("tty_lock", "true"));
 
     // Theme stuff
     options.insert(option("input_panel_x", "50%"));
@@ -96,6 +95,7 @@ Cfg::Cfg()
     options.insert(option("passwd_feedback_msg", "Authentication failed"));
     options.insert(option("show_username", "1"));
     options.insert(option("show_welcome_msg", "0"));
+    options.insert(option("tty_lock", "1"));
 
     error = "";
 }

--- a/slimlock.conf
+++ b/slimlock.conf
@@ -7,3 +7,4 @@ passwd_feedback_y               10%
 passwd_feedback_msg             Authentication failed
 show_username                   1
 show_welcome_msg                0
+tty_lock                        1

--- a/slimlock.cpp
+++ b/slimlock.cpp
@@ -165,7 +165,7 @@ int main(int argc, char **argv) {
         die("PAM: %s\n", pam_strerror(pam_handle, ret));
 
     // disable tty switching
-    if(cfg->getOption("tty_lock") == "true") {
+    if(cfg->getOption("tty_lock") == "1") {
         if ((term = open("/dev/console", O_RDWR)) == -1) {
             perror("error opening console");
         }   
@@ -225,7 +225,7 @@ int main(int argc, char **argv) {
         break;
     }
 
-    if(cfg->getOption("tty_lock") == "true") {
+    if(cfg->getOption("tty_lock") == "1") {
         if ((ioctl(term, VT_UNLOCKSWITCH)) == -1) {
             perror("error unlocking console");
         }

--- a/slimlock.cpp
+++ b/slimlock.cpp
@@ -165,12 +165,14 @@ int main(int argc, char **argv) {
         die("PAM: %s\n", pam_strerror(pam_handle, ret));
 
     // disable tty switching
-    if ((term = open("/dev/console", O_RDWR)) == -1) {
-        perror("error opening console");
-    }
+    if(cfg->getOption("tty_lock") == "true") {
+        if ((term = open("/dev/console", O_RDWR)) == -1) {
+            perror("error opening console");
+        }   
 
-    if ((ioctl(term, VT_LOCKSWITCH)) == -1) {
-        perror("error locking console");
+        if ((ioctl(term, VT_LOCKSWITCH)) == -1) {
+            perror("error locking console");
+        }
     }
 
     // Set up DPMS
@@ -223,8 +225,10 @@ int main(int argc, char **argv) {
         break;
     }
 
-    if ((ioctl(term, VT_UNLOCKSWITCH)) == -1) {
-        perror("error unlocking console");
+    if(cfg->getOption("tty_lock") == "true") {
+        if ((ioctl(term, VT_UNLOCKSWITCH)) == -1) {
+            perror("error unlocking console");
+        }
     }
     close(term);
 


### PR DESCRIPTION
This feature was causing problems with suspend on my system and isn't something I personally wanted. I added a config option "tty_lock" to enable/disable the feature. It is enabled by default.
