### PR TITLE
Allow disabling the bell rung on authentication failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ are:
 -	`tty_lock`: whether or not to allow virtual terminals switching. 1 to
 	disallow, 0 to allow.
 	-	Default: 1
+-	`bell`: whether to ring the bell on authentication failure. 1 to
+	enable, 0 to disable.
+	-	Default: 1
 
 Copyright
 ---------

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ are:
 -	`show_welcome_msg`: whether or not to display SLiM's welcome message. 1 to
 	show, 0 to disable.
 	-	Default: 0
+-	`tty_lock`: whether or not to allow virtual terminals switching. 1 to
+	disallow, 0 to allow.
+	-	Default: 1
 
 Copyright
 ---------

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -96,6 +96,7 @@ Cfg::Cfg()
     options.insert(option("show_username", "1"));
     options.insert(option("show_welcome_msg", "0"));
     options.insert(option("tty_lock", "1"));
+    options.insert(option("bell", "1"));
 
     error = "";
 }

--- a/panel.cpp
+++ b/panel.cpp
@@ -213,7 +213,10 @@ void Panel::WrongPassword(int timeout) {
     OnExpose();
     SlimDrawString8(draw, &msgcolor, msgfont, msg_x, msg_y, message,
                     &msgshadowcolor, shadowXOffset, shadowYOffset);
-    XBell(Dpy, 100);
+
+    if (cfg->getOption("bell") == "1") {
+      XBell(Dpy, 100);
+    }
 
     XFlush(Dpy);
     sleep(timeout);

--- a/slimlock.1
+++ b/slimlock.1
@@ -45,5 +45,9 @@ message to display after a failed authentication attempt.
 .B show_welcome_msg
 1 to show SLiM's welcome message; 0 to disable.
 .BI "Default: " 0
+.TP
+.B tty_lock
+1 to disallow virtual terminals switching; 0 to allow.
+.BI "Default: " 1
 .SH "SEE ALSO"
 .BR slim (1)

--- a/slimlock.1
+++ b/slimlock.1
@@ -49,5 +49,9 @@ message to display after a failed authentication attempt.
 .B tty_lock
 1 to disallow virtual terminals switching; 0 to allow.
 .BI "Default: " 1
+.TP
+.B bell
+1 to enable the bell on authentication failure; 0 to disable.
+.BI "Default: " 1
 .SH "SEE ALSO"
 .BR slim (1)


### PR DESCRIPTION
Personally, I get annoyed by the sudden bell if I mistype something in my password. So I added an ability to disable it via configuration file. The default value is to still to ring it. So no behaviour change here. Along the way I also documented tty_lock option.
