### PR TITLE
Handle windows popping above the slimlock better.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.*.swp
 *.o
 slimlock

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CXX = g++
 CC  = gcc
 
 PKGS=x11 xrandr xft fontconfig imlib2 xext
-MYCFLAGS=-Wall -I. $(shell pkg-config --cflags $(PKGS)) -pthread
+MYCFLAGS=-Wall -I. $(shell pkg-config --cflags $(PKGS)) -pthread 
 CXXFLAGS=$(CFLAGS) $(MYCFLAGS)
 LIBS=$(shell pkg-config --libs $(PKGS)) -lrt -lpam -pthread
 CUSTOM=

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CXX = g++
 CC  = gcc
 
 PKGS=x11 xrandr xft fontconfig imlib2 xext
-MYCFLAGS=-Wall -I. $(shell pkg-config --cflags $(PKGS)) -pthread 
+MYCFLAGS=-Wall -I. $(shell pkg-config --cflags $(PKGS)) -pthread
 CXXFLAGS=$(CFLAGS) $(MYCFLAGS)
 LIBS=$(shell pkg-config --libs $(PKGS)) -lrt -lpam -pthread
 CUSTOM=
@@ -47,3 +47,9 @@ install: slimlock
 	@chmod u+s $(DESTDIR)$(PREFIX)/bin/slimlock
 	@install -D -m 644 slimlock.conf $(DESTDIR)$(CFGDIR)/slimlock.conf
 	@install -D -m 644 slimlock.pam $(DESTDIR)$(CFGDIR)/pam.d/slimlock
+
+uninstall:
+	@rm -f $(DESTDIR)$(MANDIR)/man1/slimlock.1
+	@rm -f $(DESTDIR)$(PREFIX)/bin/slimlock
+	@rm -f $(DESTDIR)$(CFGDIR)/slimlock.conf
+	@rm -f $(DESTDIR)$(CFGDIR)/pam.d/slimlock

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-NO LONGER MAINTAINED
+Once Again Maintained
 ====================
-As of October 7 I (Joel Burget) have given up maintainership of this project.
-Feel free to use it but I am no longer fixing bugs.
+Maintenance of this project has been picked up by me (danny noest).  Please 
+feel free to toss any bugs my way (dnoest@gmail.com). 
 
 slimlock - unholy screen locker
 ===============================

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ are:
 -	`bell`: whether to ring the bell on authentication failure. 1 to
 	enable, 0 to disable.
 	-	Default: 1
+-	`passwd_char`: character to display when masking password. Only the first
+	character is used.
+	-	Default: *
 
 Copyright
 ---------

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ are:
 -	`passwd_char`: character to display when masking password. Only the first
 	character is used.
 	-	Default: *
+-	`raise_interval`: raise slimlock window every this number of milliseconds.
+	This is needed to hide other windows that can potentially pop on top of
+	slimlock (e.g. various notifications). 0 to disable.
+	-	Default: 1000
 
 Copyright
 ---------

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -98,6 +98,7 @@ Cfg::Cfg()
     options.insert(option("show_welcome_msg", "0"));
     options.insert(option("tty_lock", "1"));
     options.insert(option("bell", "1"));
+    options.insert(option("passwd_char", "*"));
 
     error = "";
 }

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -24,7 +24,7 @@ using namespace std;
 
 typedef pair<string,string> option;
 
-Cfg::Cfg() 
+Cfg::Cfg()
 {
     // Configuration options
     options.insert(option("screenshot_cmd", "import -window root /slim.png"));
@@ -151,23 +151,19 @@ string& Cfg::getOption(string option) {
 
 /* return a trimmed string */
 string Cfg::trim( const string& s ) {
-    if ( s.empty() ) {
+    if ( s.empty() )
         return s;
-    }
     int pos = 0;
     string line = s;
     int len = line.length();
-    while (pos < len && isspace(line[pos])) {
+    while (pos < len && isspace(line[pos]))
         ++pos;
-    }
     line.erase( 0, pos );
     pos = line.length() - 1;
-    while (pos > -1 && isspace(line[pos])) {
+    while (pos > -1 && isspace(line[pos]))
         --pos;
-    }
-    if ( pos != -1 ) {
+    if ( pos != -1 )
         line.erase( pos+1 );
-    }
     return line;
 }
 
@@ -199,9 +195,8 @@ string Cfg::getWelcomeMessage() {
 int Cfg::string2int(const char* string, bool* ok) {
     char* err = 0;
     int l = (int)strtol(string, &err, 10);
-    if (ok) {
+    if (ok)
         *ok = (*err == 0);
-    }
     return (*err == 0) ? l : 0;
 }
 
@@ -212,9 +207,8 @@ int Cfg::absolutepos(const string& position, int max, int width) {
     if (n>0) { // X Position expressed in percentage
         int result = (max*string2int(position.substr(0, n).c_str())/100) - (width / 2);
         return result < 0 ? 0 : result ;
-    } else { // Absolute X position
+    } else // Absolute X position
         return string2int(position.c_str());
-    }
 }
 
 // split a comma separated string into a vector of strings
@@ -224,15 +218,15 @@ void Cfg::split(vector<string>& v, const string& str, char c, bool useEmpty) {
     string tmp;
     while (true) {
         string::const_iterator begin = s;
-        while (*s != c && s != str.end()) { ++s; }
-    tmp = string(begin, s);
-    if (useEmpty || tmp.size() > 0)
+        while (*s != c && s != str.end())
+            ++s;
+        tmp = string(begin, s);
+        if (useEmpty || tmp.size() > 0)
             v.push_back(tmp);
-        if (s == str.end()) {
+        if (s == str.end())
             break;
-        }
         if (++s == str.end()) {
-        if (useEmpty)
+            if (useEmpty)
                 v.push_back("");
             break;
         }

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -99,6 +99,7 @@ Cfg::Cfg()
     options.insert(option("tty_lock", "1"));
     options.insert(option("bell", "1"));
     options.insert(option("passwd_char", "*"));
+    options.insert(option("raise_interval", "1000"));
 
     error = "";
 }

--- a/cfg.h
+++ b/cfg.h
@@ -36,14 +36,13 @@ public:
 
     static int absolutepos(const std::string& position, int max, int width);
     static int string2int(const char* string, bool* ok = 0);
-    static void split(std::vector<std::string>& v, const std::string& str, 
+    static void split(std::vector<std::string>& v, const std::string& str,
                       char c, bool useEmpty=true);
     static std::string trim(const std::string& s);
 
 private:
     std::map<std::string,std::string> options;
     std::string error;
-
 };
 
 #endif

--- a/image.cpp
+++ b/image.cpp
@@ -57,9 +57,8 @@ Image::Resize(const int w, const int h) {
  * background, the background must contain the image.
  */
 void Image::Merge(Image* background, const int x, const int y) {
-    if (x + width > background->Width()|| y + height > background->Height()) {
+    if (x + width > background->Width()|| y + height > background->Height())
         return;
-    }
 
     Imlib_Image bg_image, new_image;
     bg_image = background->GetImage();
@@ -88,10 +87,9 @@ void Image::Tile(const int w, const int h) {
     tiles_x = w / width;
     tiles_y = h / height;
     for(int i=0; i <= tiles_x; i++) {
-        for(int j=0; j <= tiles_y; j++) {
+        for(int j=0; j <= tiles_y; j++)
             imlib_blend_image_onto_image(image, 0, 0, 0, width, height,
                                          i * width, j * height, width, height);
-        }
     }
 
     width = w;

--- a/image.h
+++ b/image.h
@@ -1,12 +1,12 @@
 /* SLiM - Simple Login Manager
    Copyright (C) 2004-06 Simone Rota <sip@varlock.com>
    Copyright (C) 2004-06 Johannes Winkelmann <jw@tks6.net>
-      
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2 of the License, or
    (at your option) any later version.
-   
+
    The following code has been adapted and extended from
    xplanet 1.0.1, Copyright (C) 2002-04 Hari Nair <hari@alumni.caltech.edu>
 */
@@ -41,10 +41,8 @@ public:
     void Crop(const int x, const int y, const int w, const int h);
     void Tile(const int w, const int h);
     void Center(const int w, const int h, const char *hex);
-    
 
     Pixmap createPixmap(Display* dpy, int scr, Window win);
-
 
 private:
     int width, height;

--- a/panel.cpp
+++ b/panel.cpp
@@ -318,6 +318,12 @@ void Panel::EventHandler() {
     while(loop) {
         XNextEvent(Dpy, &event);
         switch(event.type) {
+            case VisibilityNotify:
+                if (event.xvisibility.state == VisibilityPartiallyObscured ||
+                    event.xvisibility.state == VisibilityFullyObscured) {
+                    XRaiseWindow(Dpy, Win);
+                }
+                break;
             case Expose:
                 OnExpose();
                 break;

--- a/panel.cpp
+++ b/panel.cpp
@@ -149,7 +149,6 @@ Panel::Panel(Display* dpy, int scr, Window win, Cfg* config,
     image->Merge(bg, X, Y);
     background = image->createPixmap(Dpy, Scr, Win);
     delete bg;
-    delete image;
 
     // Read (and substitute vars in) the welcome message
     int show_welcome_msg = Cfg::string2int(cfg->getOption("show_welcome_msg").c_str());
@@ -182,6 +181,7 @@ Panel::~Panel() {
     XftFontClose(Dpy, introfont);
     XftFontClose(Dpy, welcomefont);
     XftFontClose(Dpy, enterfont);
+    delete image;
 
     XFreeGC(Dpy, WinGC);
     XFreePixmap(Dpy, background);

--- a/panel.cpp
+++ b/panel.cpp
@@ -119,12 +119,11 @@ Panel::Panel(Display* dpy, int scr, Window win, Cfg* config,
         }
     }
 
-    if (bgstyle == "stretch") {
+    if (bgstyle == "stretch")
         bg->Resize(viewport[0].width, viewport[0].height);
-    } else if (bgstyle == "tile") {
-        bg->Tile(viewport[0].width,
-                 viewport[0].height);
-    } else if (bgstyle == "center") {
+    else if (bgstyle == "tile")
+        bg->Tile(viewport[0].width, viewport[0].height);
+    else if (bgstyle == "center") {
         string hexvalue = cfg->getOption("background_color");
         hexvalue = hexvalue.substr(1,6);
         bg->Center(viewport[0].width,
@@ -150,9 +149,8 @@ Panel::Panel(Display* dpy, int scr, Window win, Cfg* config,
     background.push_back(image->createPixmap(Dpy, Scr, Win));
 
     // Create rest of backgrounds (without password boxes)
-    for (unsigned int i = 1; i < viewport.size(); ++i) {
+    for (unsigned int i = 1; i < viewport.size(); ++i)
         background.push_back(bg->createPixmap(Dpy, Scr, Win));
-    }
     delete bg;
 
     // Read (and substitute vars in) the welcome message
@@ -226,9 +224,8 @@ void Panel::WrongPassword(int timeout) {
     SlimDrawString8(draw, &msgcolor, msgfont, msg_x, msg_y, message,
                     &msgshadowcolor, shadowXOffset, shadowYOffset);
 
-    if (cfg->getOption("bell") == "1") {
-      XBell(Dpy, 100);
-    }
+    if (cfg->getOption("bell") == "1")
+        XBell(Dpy, 100);
 
     XFlush(Dpy);
     sleep(timeout);
@@ -308,9 +305,8 @@ void Panel::Cursor(int visible) {
         XDrawLine(Dpy, Win, TextGC,
                   xx+1, yy-cheight,
                   xx+1, y2);
-    } else {
+    } else
         ApplyBackground(Rectangle(xx+1, yy-cheight, 1, y2-(yy-cheight)+1), 0);
-    }
 }
 
 void Panel::EventHandler() {
@@ -337,9 +333,8 @@ void Panel::OnExpose(void) {
     XftDraw *draw = XftDrawCreate(Dpy, Win,
                         DefaultVisual(Dpy, Scr), DefaultColormap(Dpy, Scr));
 
-    for (unsigned int i = 0; i < viewport.size(); ++i) {
+    for (unsigned int i = 0; i < viewport.size(); ++i)
         ApplyBackground(Rectangle(), i);
-    }
 
     if (input_pass_x != input_name_x || input_pass_y != input_name_y) {
         SlimDrawString8(draw, &inputcolor, font, input_name_x, input_name_y,
@@ -371,7 +366,7 @@ bool Panel::OnKeyPress(XEvent& event) {
     bool fieldTextChanged = true;
 
     XLookupString(&event.xkey, &ascii, 1, &keysym, &compstatus);
-    
+
     // Check capslock
     CapsLockOn = ((event.xkey.state & LockMask) != 0);
 
@@ -415,9 +410,8 @@ bool Panel::OnKeyPress(XEvent& event) {
                     PasswdBuffer.push_back(ascii);
                     HiddenPasswdBuffer.push_back('*');
                 }
-            } else {
+            } else
                 fieldTextChanged = false;
-            }
             break;
     }
 
@@ -494,10 +488,9 @@ void Panel::ShowText() {
 		Cfg::string2int(cfg->getOption("username_shadow_yoffset").c_str());
 	password_x = Cfg::absolutepos(cfgX, image->Width(), extents.width) + X;
 	password_y = Cfg::absolutepos(cfgY, image->Height(), extents.height) + Y;
-	if (password_x >= 0 && password_y >= 0) {
+	if (password_x >= 0 && password_y >= 0)
 		SlimDrawString8 (draw, &entercolor, enterfont, password_x, password_y,
 						 msg, &entershadowcolor, shadowXOffset, shadowYOffset);
-	}
 
     if (!singleInputMode) {
         msg = cfg->getOption("username_msg");
@@ -511,10 +504,9 @@ void Panel::ShowText() {
             Cfg::string2int(cfg->getOption("username_shadow_yoffset").c_str());
         username_x = Cfg::absolutepos(cfgX, image->Width(), extents.width) + X;
         username_y = Cfg::absolutepos(cfgY, image->Height(), extents.height) + Y;
-        if (username_x >= 0 && username_y >= 0) {
+        if (username_x >= 0 && username_y >= 0)
             SlimDrawString8 (draw, &entercolor, enterfont, username_x, username_y,
                              msg, &entershadowcolor, shadowXOffset, shadowYOffset);
-        }
     }
     XftDrawDestroy(draw);
 
@@ -530,10 +522,9 @@ void Panel::SlimDrawString8(XftDraw *d, XftColor *color, XftFont *font,
                             XftColor* shadowColor,
                             int xOffset, int yOffset)
 {
-    if (xOffset && yOffset) {
+    if (xOffset && yOffset)
         XftDrawString8(d, shadowColor, font, x+xOffset+viewport[0].x, y+yOffset+viewport[0].y,
                        reinterpret_cast<const FcChar8*>(str.c_str()), str.length());
-    }
     XftDrawString8(d, color, font, x+viewport[0].x, y+viewport[0].y, reinterpret_cast<const FcChar8*>(str.c_str()), str.length());
 }
 
@@ -570,33 +561,29 @@ std::vector<Rectangle> Panel::GetPrimaryViewport() {
         DisplayHeight(Dpy,Scr)));
 
     primary = XRRGetOutputPrimary(Dpy, Win);
-    if (!primary) {
+    if (!primary)
         return fallback;
-    }
 
     resources = XRRGetScreenResources(Dpy, Win);
-    if (!resources) {
+    if (!resources)
         return fallback;
-    }
 
     primary_info = XRRGetOutputInfo(Dpy, resources, primary);
     if (!primary_info) {
         XRRFreeScreenResources(resources);
         return fallback;
     }
-       
+
     if (primary_info->crtc < 1) {
         if (primary_info->ncrtc > 0) {
-           for (int i = 0; i < primary_info->ncrtc; ++i) {
+           for (int i = 0; i < primary_info->ncrtc; ++i)
                 crtcs.push_back(primary_info->crtcs[i]);
-            }
         } else {
             cerr << "Cannot get crtc from xrandr.\n";
             return fallback;
         }
-    } else {
+    } else
         crtcs.push_back(primary_info->crtc);
-    }
 
     for (unsigned int i = 0; i < crtcs.size(); ++i) {
         crtc_info = XRRGetCrtcInfo(Dpy, resources, crtcs[i]);
@@ -609,7 +596,7 @@ std::vector<Rectangle> Panel::GetPrimaryViewport() {
             return fallback;
         }
 
-        result.push_back(Rectangle(crtc_info->x, crtc_info->y, 
+        result.push_back(Rectangle(crtc_info->x, crtc_info->y,
             crtc_info->width, crtc_info->height));
         XRRFreeCrtcInfo(crtc_info);
     }
@@ -634,7 +621,6 @@ void Panel::ApplyBackground(Rectangle rect, int vp) {
                     rect.x, rect.y, rect.width, rect.height,
                     viewport[vp].x + rect.x, viewport[vp].y + rect.y);
 
-    if (!ret) {
+    if (!ret)
         cerr << APPNAME << ": failed to put pixmap on the screen\n.";
-    }
 }

--- a/panel.cpp
+++ b/panel.cpp
@@ -552,6 +552,8 @@ Rectangle Panel::GetPrimaryViewport() {
     XRRScreenResources *resources;
     XRRCrtcInfo *crtc_info;
 
+    int crtc;
+
     fallback.x = 0;
     fallback.y = 0;
     fallback.width = DisplayWidth(Dpy, Scr);
@@ -572,8 +574,24 @@ Rectangle Panel::GetPrimaryViewport() {
         XRRFreeScreenResources(resources);
         return fallback;
     }
+    if (primary_info->crtc < 1) {
+        if (primary_info->ncrtc > 0) {
+            // just use the first one. 
+            // i do not know what the consequences
+            // of this will be. it seems to be that the index
+            // is which monitor to use.  
+            crtc = primary_info->crtcs[0];
+        } else {
+            cerr << "Cannot get crtc from xrandr.\n";
+            exit(EXIT_FAILURE);
+        }
+    } else {
+        crtc = primary_info->crtc;
+    }
+    // this is the function call its dying on 
+    crtc_info = XRRGetCrtcInfo(Dpy, resources, crtc);
 
-    crtc_info = XRRGetCrtcInfo(Dpy, resources, primary_info->crtc);
+
     if (!crtc_info) {
         XRRFreeOutputInfo(primary_info);
         XRRFreeScreenResources(resources);

--- a/panel.cpp
+++ b/panel.cpp
@@ -74,6 +74,8 @@ Panel::Panel(Display* dpy, int scr, Window win, Cfg* config,
     input_name_y = Cfg::string2int(cfg->getOption("input_name_y").c_str());
     input_pass_x = Cfg::string2int(cfg->getOption("input_pass_x").c_str());
     input_pass_y = Cfg::string2int(cfg->getOption("input_pass_y").c_str());
+    password_char = cfg->getOption("passwd_char").c_str()[0];
+
     inputShadowXOffset =
         Cfg::string2int(cfg->getOption("input_shadow_xoffset").c_str());
     inputShadowYOffset =
@@ -413,7 +415,7 @@ bool Panel::OnKeyPress(XEvent& event) {
                 formerString=HiddenPasswdBuffer;
                 if (PasswdBuffer.length() < INPUT_MAXLENGTH_PASSWD - 1) {
                     PasswdBuffer.push_back(ascii);
-                    HiddenPasswdBuffer.push_back('*');
+                    HiddenPasswdBuffer.push_back(password_char);
                 }
             } else {
                 fieldTextChanged = false;

--- a/panel.cpp
+++ b/panel.cpp
@@ -16,6 +16,10 @@
 #include <unistd.h>
 #include <X11/extensions/Xrandr.h>
 
+#include <sys/select.h>
+#include <time.h>
+#include <errno.h>
+
 using namespace std;
 
 Panel::Panel(Display* dpy, int scr, Window win, Cfg* config,
@@ -25,6 +29,7 @@ Panel::Panel(Display* dpy, int scr, Window win, Cfg* config,
 
     // Set display
     Dpy = dpy;
+    DpyFd = ConnectionNumber(Dpy);
     Scr = scr;
     Win = win;
     cfg = config;
@@ -168,6 +173,15 @@ Panel::Panel(Display* dpy, int scr, Window win, Cfg* config,
 
     // Draw the panel for the first time
     OnExpose();
+
+    raise_interval = Cfg::string2int(cfg->getOption("raise_interval").c_str());
+    if (raise_interval == 0) {
+        // don't raise window periodically; actually just raise it rarely
+        raise_interval = 3600 * 1000;
+    }
+
+    last_raise_time.tv_sec = 0;
+    last_raise_time.tv_nsec = 0;
 }
 
 Panel::~Panel() {
@@ -314,23 +328,50 @@ void Panel::Cursor(int visible) {
 void Panel::EventHandler() {
     XEvent event;
     bool loop = true;
+
     //OnExpose();
     while(loop) {
-        XNextEvent(Dpy, &event);
-        switch(event.type) {
-            case VisibilityNotify:
-                if (event.xvisibility.state == VisibilityPartiallyObscured ||
-                    event.xvisibility.state == VisibilityFullyObscured) {
-                    XRaiseWindow(Dpy, Win);
-                }
-                break;
-            case Expose:
-                OnExpose();
-                break;
+        fd_set fds;
+        int ret;
 
-            case KeyPress:
-                loop = OnKeyPress(event);
-                break;
+        FD_ZERO(&fds);
+        FD_SET(DpyFd, &fds);
+
+        UpdateRaiseTimeout();
+        ret = select(DpyFd + 1, &fds, 0, 0, &raise_timeout);
+        if (ret == 0) {
+            // timeout; raising our window
+            XRaiseWindow(Dpy, Win);
+        } else if (ret < 0) {
+            int select_errno = errno;
+
+            if (select_errno == EINTR) {
+              continue;
+            }
+
+            cerr << APPNAME << ": select failed ("
+                 << strerror(select_errno) << ")\n";
+            exit(ERR_EXIT);
+        }
+
+        while (loop && XPending(Dpy)) {
+            XNextEvent(Dpy, &event);
+
+            switch(event.type) {
+                case VisibilityNotify:
+                    if (event.xvisibility.state == VisibilityPartiallyObscured ||
+                        event.xvisibility.state == VisibilityFullyObscured) {
+                        XRaiseWindow(Dpy, Win);
+                    }
+                    break;
+                case Expose:
+                    OnExpose();
+                    break;
+
+                case KeyPress:
+                    loop = OnKeyPress(event);
+                    break;
+            }
         }
     }
 
@@ -631,4 +672,45 @@ void Panel::ApplyBackground(Rectangle rect, int vp) {
 
     if (!ret)
         cerr << APPNAME << ": failed to put pixmap on the screen\n.";
+}
+
+bool Panel::GetCurrentTime(struct timespec *time) const {
+    int ret = clock_gettime(CLOCK_MONOTONIC, time);
+    if (ret == 0) {
+        return true;
+    } else {
+        int gettime_errno = errno;
+        cerr << APPNAME << ": clock_gettime failed ("
+             << strerror(gettime_errno) << ")\n";
+
+        return false;
+    }
+}
+
+void Panel::UpdateRaiseTimeout() {
+    struct timespec curr_time;
+
+    if (GetCurrentTime(&curr_time)) {
+        // past time in milliseconds
+        int past_time;
+
+        past_time = (curr_time.tv_sec - last_raise_time.tv_sec) * 1000;
+        past_time += (curr_time.tv_nsec - last_raise_time.tv_nsec) / 1000000;
+
+        if (past_time >= raise_interval) {
+            last_raise_time = curr_time;
+
+            raise_timeout.tv_sec = 0;
+            raise_timeout.tv_usec = 0;
+        } else {
+            int left_time = raise_interval - past_time;
+
+            raise_timeout.tv_sec = left_time / 1000;
+            raise_timeout.tv_usec = (left_time % 1000) * 1000;
+        }
+    } else {
+        // failed to grab time; force window to raise just in case
+        raise_timeout.tv_sec = 0;
+        raise_timeout.tv_usec = 0;
+    }
 }

--- a/panel.h
+++ b/panel.h
@@ -42,8 +42,9 @@ struct Rectangle {
     Rectangle() : x(0), y(0), width(0), height(0) {};
     Rectangle(int x, int y, unsigned int width, unsigned int height) :
         x(x), y(y), width(width), height(height) {};
-    bool is_empty() const
-      return width == 0 || height == 0;
+    bool is_empty() const {
+        return width == 0 || height == 0;
+    }
 };
 
 class Panel {

--- a/panel.h
+++ b/panel.h
@@ -134,6 +134,7 @@ private:
     int password_y;
     std::string welcome_message;
     std::string intro_message;
+    char password_char;
 
     Image* image;
 

--- a/panel.h
+++ b/panel.h
@@ -22,6 +22,7 @@
 #include <signal.h>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #ifdef NEEDS_BASENAME
 #include <libgen.h>
@@ -60,6 +61,7 @@ public:
     void SetName(const std::string& name);
     const std::string& GetName(void) const;
     const std::string& GetPasswd(void) const;
+
 private:
     Panel();
     void Cursor(int visible);
@@ -73,8 +75,8 @@ private:
                             XftColor* shadowColor,
                             int xOffset, int yOffset);
 
-    Rectangle GetPrimaryViewport();
-    void ApplyBackground(Rectangle = Rectangle());
+    std::vector<Rectangle> GetPrimaryViewport();
+    void ApplyBackground(Rectangle, int vp);
 
     Cfg* cfg;
     bool CapsLockOn;
@@ -100,7 +102,7 @@ private:
     XftFont* enterfont;
     XftColor entercolor;
     XftColor entershadowcolor;
-    Pixmap   background;
+    std::vector<Pixmap>   background;
 
     // Username/Password
     std::string NameBuffer;
@@ -108,7 +110,7 @@ private:
     std::string HiddenPasswdBuffer;
 
     // screen stuff
-    Rectangle viewport;
+    std::vector<Rectangle> viewport;
 
     // Configuration
     int input_name_x;

--- a/panel.h
+++ b/panel.h
@@ -34,17 +34,16 @@
 #include "image.h"
 
 struct Rectangle {
-  int x;
-  int y;
-  unsigned int width;
-  unsigned int height;
+    int x;
+    int y;
+    unsigned int width;
+    unsigned int height;
 
-  Rectangle() : x(0), y(0), width(0), height(0) {};
-  Rectangle(int x, int y, unsigned int width, unsigned int height) :
-      x(x), y(y), width(width), height(height) {};
-  bool is_empty() const {
-    return width == 0 || height == 0;
-  }
+    Rectangle() : x(0), y(0), width(0), height(0) {};
+    Rectangle(int x, int y, unsigned int width, unsigned int height) :
+        x(x), y(y), width(width), height(height) {};
+    bool is_empty() const
+      return width == 0 || height == 0;
 };
 
 class Panel {
@@ -139,7 +138,6 @@ private:
 
     // For thesting themes
     std::string themedir;
-
 };
 
 #endif

--- a/panel.h
+++ b/panel.h
@@ -78,6 +78,9 @@ private:
     std::vector<Rectangle> GetPrimaryViewport();
     void ApplyBackground(Rectangle, int vp);
 
+    bool GetCurrentTime(struct timespec *time) const;
+    void UpdateRaiseTimeout();
+
     Cfg* cfg;
     bool CapsLockOn;
 
@@ -85,6 +88,7 @@ private:
     Window Win;
     GC WinGC;
     Display* Dpy;
+    int DpyFd;
     int Scr;
     int X, Y;
     GC TextGC;
@@ -103,6 +107,10 @@ private:
     XftColor entercolor;
     XftColor entershadowcolor;
     std::vector<Pixmap>   background;
+
+    int raise_interval;
+    struct timespec last_raise_time;
+    struct timeval raise_timeout;
 
     // Username/Password
     std::string NameBuffer;

--- a/slimlock.1
+++ b/slimlock.1
@@ -61,5 +61,10 @@ message to display after a failed authentication attempt if the CapsLock is on.
 .B passwd_char
 Character to show when masking password.
 .BI "Default: " *
+.B raise_interval
+raise slimlock window every this number of milliseconds. This is needed to
+hide other windows that can potentially pop on top of slimlock (e.g. various
+notifications). 0 to disable.
+.BI "Default: " 1000
 .SH "SEE ALSO"
 .BR slim (1)

--- a/slimlock.1
+++ b/slimlock.1
@@ -57,5 +57,9 @@ message to display after a failed authentication attempt if the CapsLock is on.
 .B bell
 1 to enable the bell on authentication failure; 0 to disable.
 .BI "Default: " 1
+.TP
+.B passwd_char
+Character to show when masking password.
+.BI "Default: " *
 .SH "SEE ALSO"
 .BR slim (1)

--- a/slimlock.cpp
+++ b/slimlock.cpp
@@ -41,7 +41,7 @@ void *RaiseWindow(void *data);
 // I really didn't wanna put these globals here, but it's the only way...
 Display* dpy;
 int scr;
-Window win;
+Window win, root;
 Cfg* cfg;
 Panel* loginPanel;
 string themeName = "";
@@ -133,6 +133,8 @@ int main(int argc, char **argv) {
     if (!display){
         display = DISPLAY;
     }
+    XInitThreads();
+
     if(!(dpy = XOpenDisplay(display)))
         die(APPNAME": cannot open display\n");
     scr = DefaultScreen(dpy);
@@ -142,7 +144,7 @@ int main(int argc, char **argv) {
     wa.background_pixel = BlackPixel(dpy, scr);
 
     // Create a full screen window
-    Window root = RootWindow(dpy, scr);
+    root = RootWindow(dpy, scr);
     win = XCreateWindow(dpy,
       root,
       0,
@@ -357,9 +359,12 @@ void HandleSignal(int sig)
     die(APPNAME": Caught signal; dying\n");
 }
 
+// i think this should be in an event loop instead of this threaded 
+// thing
 void* RaiseWindow(void *data) {
     while(1) {
         XRaiseWindow(dpy, win);
+        XGrabKeyboard(dpy, root, True, GrabModeAsync, GrabModeAsync, CurrentTime);
         sleep(1);
     }
 }

--- a/slimlock.cpp
+++ b/slimlock.cpp
@@ -242,6 +242,7 @@ int main(int argc, char **argv) {
 
     XCloseDisplay(dpy);
 
+    flock(lock_file, LOCK_UN);
     close(lock_file);
 
     if(cfg->getOption("tty_lock") == "1") {

--- a/slimlock.cpp
+++ b/slimlock.cpp
@@ -73,7 +73,8 @@ int main(int argc, char **argv) {
 
     // restore DPMS settings should slimlock be killed in the line of duty
     prev_fn = signal(SIGTERM, HandleSignal);
-    if (prev_fn == SIG_IGN) signal(SIGTERM, SIG_IGN);
+    if (prev_fn == SIG_IGN)
+        signal(SIGTERM, SIG_IGN);
 
     // create a lock file to solve mutliple instances problem
     // /var/lock used to be the place to put this, now it's /run/lock
@@ -106,9 +107,8 @@ int main(int argc, char **argv) {
     themebase = string(THEMESDIR) + "/";
     themeName = cfg->getOption("current_theme");
     string::size_type pos;
-    if ((pos = themeName.find(",")) != string::npos) {
+    if ((pos = themeName.find(",")) != string::npos)
         themeName = findValidRandomTheme(themeName);
-    }
 
     bool loaded = false;
     while (!loaded) {
@@ -124,15 +124,13 @@ int main(int argc, char **argv) {
                      << themeName << endl;
                 themeName = "default";
             }
-        } else {
+        } else
             loaded = true;
-        }
     }
 
     const char *display = getenv("DISPLAY");
-    if (!display){
+    if (!display)
         display = DISPLAY;
-    }
     XInitThreads();
 
     if(!(dpy = XOpenDisplay(display)))
@@ -146,17 +144,17 @@ int main(int argc, char **argv) {
     // Create a full screen window
     root = RootWindow(dpy, scr);
     win = XCreateWindow(dpy,
-      root,
-      0,
-      0,
-      DisplayWidth(dpy, scr),
-      DisplayHeight(dpy, scr),
-      0,
-      DefaultDepth(dpy, scr),
-      CopyFromParent,
-      DefaultVisual(dpy, scr),
-      CWOverrideRedirect | CWBackPixel,
-      &wa);
+        root,
+        0,
+        0,
+        DisplayWidth(dpy, scr),
+        DisplayHeight(dpy, scr),
+        0,
+        DefaultDepth(dpy, scr),
+        CopyFromParent,
+        DefaultVisual(dpy, scr),
+        CWOverrideRedirect | CWBackPixel,
+        &wa);
     XMapWindow(dpy, win);
 
     XFlush(dpy);
@@ -183,13 +181,11 @@ int main(int argc, char **argv) {
 
     // disable tty switching
     if(cfg->getOption("tty_lock") == "1") {
-        if ((term = open("/dev/console", O_RDWR)) == -1) {
+        if ((term = open("/dev/console", O_RDWR)) == -1)
             perror("error opening console");
-        }
 
-        if ((ioctl(term, VT_LOCKSWITCH)) == -1) {
+        if ((ioctl(term, VT_LOCKSWITCH)) == -1)
             perror("error locking console");
-        }
     }
 
     // Set up DPMS
@@ -248,9 +244,8 @@ int main(int argc, char **argv) {
     close(lock_file);
 
     if(cfg->getOption("tty_lock") == "1") {
-        if ((ioctl(term, VT_UNLOCKSWITCH)) == -1) {
+        if ((ioctl(term, VT_UNLOCKSWITCH)) == -1)
             perror("error unlocking console");
-        }
     }
     close(term);
 
@@ -314,9 +309,8 @@ string findValidRandomTheme(const string& set)
     string name = set;
     struct stat buf;
 
-    if (name[name.length() - 1] == ',') {
+    if (name[name.length() - 1] == ',')
         name.erase(name.length() - 1);
-    }
 
     Util::srandom(Util::makeseed());
 
@@ -348,9 +342,8 @@ void HandleSignal(int sig)
             DPMSDisable(dpy);
     }
 
-    if ((ioctl(term, VT_UNLOCKSWITCH)) == -1) {
+    if ((ioctl(term, VT_UNLOCKSWITCH)) == -1)
         perror("error unlocking console");
-    }
     close(term);
 
     loginPanel->ClosePanel();
@@ -359,7 +352,7 @@ void HandleSignal(int sig)
     die(APPNAME": Caught signal; dying\n");
 }
 
-// i think this should be in an event loop instead of this threaded 
+// i think this should be in an event loop instead of this threaded
 // thing
 void* RaiseWindow(void *data) {
     while(1) {

--- a/slimlock.cpp
+++ b/slimlock.cpp
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
     // ...i think
     struct stat statbuf;
     int lock_file;
-    
+
     // try /run/lock first, since i believe it's preferred
     if (!stat("/run/lock", &statbuf))
         lock_file = open("/run/lock/"APPNAME".lock", O_CREAT | O_RDWR, 0666);
@@ -88,12 +88,12 @@ int main(int argc, char **argv) {
         lock_file = open("/var/lock/"APPNAME".lock", O_CREAT | O_RDWR, 0666);
 
     int rc = flock(lock_file, LOCK_EX | LOCK_NB);
-        
+
     if(rc) {
         if(EWOULDBLOCK == errno)
             die(APPNAME" already running\n");
     }
-    
+
     unsigned int cfg_passwd_timeout;
     // Read user's current theme
     cfg = new Cfg;
@@ -222,13 +222,13 @@ int main(int argc, char **argv) {
         // AuthenticateUser returns true if authenticated
         if (AuthenticateUser())
             break;
-        
+
         loginPanel->WrongPassword(cfg_passwd_timeout);
     }
-    
+
     // kill thread before destroying the window that it's supposed to be raising
     pthread_cancel(raise_thread);
-    
+
     loginPanel->ClosePanel();
     delete loginPanel;
 
@@ -241,7 +241,7 @@ int main(int argc, char **argv) {
     }
 
     XCloseDisplay(dpy);
-    
+
     close(lock_file);
 
     if(cfg->getOption("tty_lock") == "1") {

--- a/util.cpp
+++ b/util.cpp
@@ -40,9 +40,8 @@ long Util::makeseed(void)
 	long pid = getpid();
 	long tm = time(NULL);
 
-	if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+	if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
 		ts.tv_sec = ts.tv_nsec = 0;
-	}
 
 	return pid + tm + (ts.tv_sec ^ ts.tv_nsec);
 }


### PR DESCRIPTION
Certain windows (especially notifications like notify-osd, etc) tend
to make their windows "override redirect". Such windows can't be
prevented from popping on top of slimlock. Previous approach of
handling this was to raise our window every second. This is definitely
better than nothing but potentially sensitive information is still
revealed for some time. And actually it didn't work at least for me
anyway: for some reason XRaiseWindow would not send Expose
event. Probably it has something to do with the fact that this
XRaiseWindow is send from another thread and Xlib is infamous for its
multithreading support. So the new approach is to handle
VisibilityNotify events and raise the window in case the event states
that our window is partially or fully obscured. This is still not
perfect since popping window will be seen as noticeable artifact. But
it seems that x11 does not give a way to handle it better.
