### PR TITLE
CapsLock advisory on password authentication failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ are:
 -	`passwd_feedback_msg`: message to display after a failed authentication
 	attempt.
 	-	Default: "Authentication failed"
+-	`passwd_feedback_capslock`: message to display after a failed authentication
+	attempt if the CapsLock is on.
+	-	Default: "Authentication failed (CapsLock is on)"
 -	`show_username`: whether or not to display the username on themes with only a
 	single input box. 1 to show, 0 to disable.
 	-	Default: 1
@@ -58,5 +61,7 @@ copyright (c) 2002-04 by Hari Nair
 Login.app is copyright (c) 1997, 1998 by Per Liden and is 
 licensed through the GNU General Public License. 
 
-Multi-monitor support adapted from xscreensaver, copyright (c) 1993-2006 Jamie 
+Multi-monitor support adapted from xscreensaver, copyright (c) 1993-2006 by Jamie 
 Zawinski <jwz@jwz.org>
+
+CapsLock handling adapted from xlockmore, copyright (c) 1998-1991 by Patrick J. Naughton

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -93,6 +93,7 @@ Cfg::Cfg()
     options.insert(option("passwd_feedback_x", "50%"));
     options.insert(option("passwd_feedback_y", "10%"));
     options.insert(option("passwd_feedback_msg", "Authentication failed"));
+    options.insert(option("passwd_feedback_capslock", "Authentication failed (CapsLock is on)"));
     options.insert(option("show_username", "1"));
     options.insert(option("show_welcome_msg", "0"));
     options.insert(option("tty_lock", "1"));

--- a/panel.cpp
+++ b/panel.cpp
@@ -27,6 +27,7 @@ Panel::Panel(Display* dpy, int scr, Window win, Cfg* config,
     Scr = scr;
     Win = win;
     cfg = config;
+    CapsLockOn = false;
 
     viewport = GetPrimaryViewport();
 
@@ -193,9 +194,13 @@ void Panel::ClosePanel() {
 }
 
 void Panel::WrongPassword(int timeout) {
-    string message = cfg->getOption("passwd_feedback_msg");
+    string message;
     string cfgX, cfgY;
     XGlyphInfo extents;
+    if (CapsLockOn)
+        message = cfg->getOption("passwd_feedback_capslock");
+    else
+        message = cfg->getOption("passwd_feedback_msg");
     XftDraw *draw = XftDrawCreate(Dpy, Win,
                                   DefaultVisual(Dpy, Scr), DefaultColormap(Dpy, Scr));
     XftTextExtents8(Dpy, msgfont, reinterpret_cast<const XftChar8*>(message.c_str()),
@@ -352,6 +357,9 @@ bool Panel::OnKeyPress(XEvent& event) {
     bool fieldTextChanged = true;
 
     XLookupString(&event.xkey, &ascii, 1, &keysym, &compstatus);
+    
+    // Check capslock
+    CapsLockOn = ((event.xkey.state & LockMask) != 0);
 
     Cursor(HIDE);
     switch(keysym){

--- a/panel.h
+++ b/panel.h
@@ -77,6 +77,7 @@ private:
     void ApplyBackground(Rectangle = Rectangle());
 
     Cfg* cfg;
+    bool CapsLockOn;
 
     // Private data
     Window Win;

--- a/slimlock.1
+++ b/slimlock.1
@@ -38,6 +38,10 @@ delay in seconds after an incorrect password is entered.
 message to display after a failed authentication attempt.
 .BI "Default: " "Authentication failed"
 .TP
+.B passwd_feedback_capslock
+message to display after a failed authentication attempt if the CapsLock is on.
+.BI "Default: " "Authentication failed (CapsLock is on)"
+.TP
 .B show_username
 1 to show username on themes with single input field; 0 to disable.
 .BI "Default: " 1

--- a/slimlock.conf
+++ b/slimlock.conf
@@ -5,6 +5,7 @@ wrong_passwd_timeout            2
 passwd_feedback_x               50%
 passwd_feedback_y               10%
 passwd_feedback_msg             Authentication failed
+passwd_feedback_capslock        Authentication failed (CapsLock is on)
 show_username                   1
 show_welcome_msg                0
 tty_lock                        0


### PR DESCRIPTION
Adds feature to display a different feedback message if authentication failed with CapsLock on.  Adapted from xlockmore.

modified:   README.md
modified:   cfg.cpp
modified:   panel.cpp
modified:   panel.h
modified:   slimlock.1
modified:   slimlock.conf
