### PR TITLE
MIssing headers

### DIFF
--- a/panel.cpp
+++ b/panel.cpp
@@ -13,6 +13,7 @@
 #include "panel.h"
 
 #include <iostream>
+#include <unistd.h>
 #include <X11/extensions/Xrandr.h>
 
 using namespace std;

--- a/slimlock.cpp
+++ b/slimlock.cpp
@@ -21,6 +21,7 @@
 #include <pthread.h>
 #include <err.h>
 #include <signal.h>
+#include <unistd.h>
 
 #include "cfg.h"
 #include "util.h"


### PR DESCRIPTION
Hi,
I was trying to compile slimlock with gcc 4.7, but got the following error message:

$ make
g++  -Wall -I. -I/usr/include/freetype2   -pthread -DPACKAGE=\"slimlock\" -DVERSION=\"0.11\" -DPKGDATADIR=\"/usr/share/slim\" -DSYSCONFDIR=\"/etc\"  -c cfg.cpp -o cfg.o
g++  -Wall -I. -I/usr/include/freetype2   -pthread -DPACKAGE=\"slimlock\" -DVERSION=\"0.11\" -DPKGDATADIR=\"/usr/share/slim\" -DSYSCONFDIR=\"/etc\"  -c image.cpp -o image.o
g++  -Wall -I. -I/usr/include/freetype2   -pthread -DPACKAGE=\"slimlock\" -DVERSION=\"0.11\" -DPKGDATADIR=\"/usr/share/slim\" -DSYSCONFDIR=\"/etc\"  -c panel.cpp -o panel.o
panel.cpp: In member function ‘void Panel::WrongPassword(int)’:
panel.cpp:219:18: error: ‘sleep’ was not declared in this scope
make: **\* [panel.o] Error 1

make
g++  -Wall -I. -I/usr/include/freetype2   -pthread -DPACKAGE=\"slimlock\" -DVERSION=\"0.11\" -DPKGDATADIR=\"/usr/share/slim\" -DSYSCONFDIR=\"/etc\"  -c panel.cpp -o panel.o
g++  -Wall -I. -I/usr/include/freetype2   -pthread -DPACKAGE=\"slimlock\" -DVERSION=\"0.11\" -DPKGDATADIR=\"/usr/share/slim\" -DSYSCONFDIR=\"/etc\"  -c slimlock.cpp -o slimlock.o
slimlock.cpp: In function ‘int main(int, char*_)’:
slimlock.cpp:164:20: error: ‘usleep’ was not declared in this scope
slimlock.cpp:244:20: error: ‘close’ was not declared in this scope
slimlock.cpp: In function ‘void HandleSignal(int)’:
slimlock.cpp:350:15: error: ‘close’ was not declared in this scope
slimlock.cpp: In function ‘void_ RaiseWindow(void_)’:
slimlock.cpp:361:16: error: ‘sleep’ was not declared in this scope
slimlock.cpp:363:1: warning: no return statement in function returning non-void [-Wreturn-type]
make: *_\* [slimlock.o] Error 1

please review my patch.
Thanks
