### PR TITLE
removing the background pixel eliminates flicker when slimlock starts.

### DIFF
--- a/slimlock.cpp
+++ b/slimlock.cpp
@@ -139,7 +139,6 @@ int main(int argc, char **argv) {
 
     XSetWindowAttributes wa;
     wa.override_redirect = 1;
-    wa.background_pixel = BlackPixel(dpy, scr);
 
     // Create a full screen window
     Window root = RootWindow(dpy, scr);
@@ -153,7 +152,7 @@ int main(int argc, char **argv) {
       DefaultDepth(dpy, scr),
       CopyFromParent,
       DefaultVisual(dpy, scr),
-      CWOverrideRedirect | CWBackPixel,
+      CWOverrideRedirect,
       &wa);
     XMapWindow(dpy, win);
 


### PR DESCRIPTION
This makes for really nice transitions on window managers such as awesome, or when the desktop background is the same as slimlocks background.
